### PR TITLE
Datetime

### DIFF
--- a/Applications/code/call_run_for_each_input.m
+++ b/Applications/code/call_run_for_each_input.m
@@ -1,9 +1,11 @@
-function call_run_for_each_input(inputI, dataL)
+function call_run_for_each_input(inputI, dataL, r_date)
 
 coreNAME_woL = 'newStack';
 dataL = dataL;
 inputN = inputI;
-r_date = date;
+
+% function is supplied r_date externally - avoids reseting r_date value
+% r_date = date; 
 exactStart = -1;
 target_est = 'step';
 dataNormalize = 0;

--- a/Applications/construct_hmm_stack.m
+++ b/Applications/construct_hmm_stack.m
@@ -22,6 +22,11 @@ save('recordSummary_info.mat', 'inputNAME', 'beginNend')
 
 %% Run the profile-HMM algorithm
 
+% AM: change date to datetime string
+t = datetime;
+DateStringTest = datestr(t);
+folderDateString = strrep(DateStringTest,' ','_');
+
 cd code
 
 % Criteria of convergence
@@ -29,7 +34,8 @@ iterTol = 0.1;  %% Iteration stops if log likelihood does not increase larger th
 iterMax = 10;   %% Iteration stops if the number of iteration is larget than iterMax.
 
 contiIter = true;
-run_for_communication('newStack', dataL, date, 1, 'step', 0);
+run_for_communication('newStack', dataL, folderDateString, 1, 'step', 0);
+% run_for_communication('newStack', dataL, date, 1, 'step', 0);
 i = 0;
 while contiIter == true
     i = i + 1;
@@ -37,7 +43,8 @@ while contiIter == true
     for inputI = 1 : length(name)
         call_run_for_each_input(inputI, dataL)
     end
-    LL(i) = run_for_communication('newStack', dataL, date, 1, 'step', 0);
+    LL(i) = run_for_communication('newStack', dataL, folderDateString, 1, 'step', 0);
+%     LL(i) = run_for_communication('newStack', dataL, date, 1, 'step', 0);
 
     if i ~= 1
         if abs(LL(i)-LL(i-1))/LL(i-1) < iterTol/100

--- a/Applications/construct_hmm_stack.m
+++ b/Applications/construct_hmm_stack.m
@@ -41,7 +41,7 @@ while contiIter == true
     i = i + 1;
     
     for inputI = 1 : length(name)
-        call_run_for_each_input(inputI, dataL)
+        call_run_for_each_input(inputI, dataL, folderDateString)
     end
     LL(i) = run_for_communication('newStack', dataL, folderDateString, 1, 'step', 0);
 %     LL(i) = run_for_communication('newStack', dataL, date, 1, 'step', 0);


### PR DESCRIPTION
Date function caused a mismatch during a multi-day run and produced the following error.

```
Error using load
Unable to read file '../../Results/19-Feb-2019/newStack_iter_updateD'. No such file or directory.

Error in run_for_each_input (line 48)
load([resultsFolder updateFileN num2str(max(preDN)) '_updateD'])

Error in call_run_for_each_input (line 10)
run_for_each_input;

Error in construct_hmm_stack (line 38)
call_run_for_each_input(inputI, dataL)
```

Calling it once and assigning it on a static value solved this issue.

Separately, adding to the string the time of run solves the issue of having to delete the output folder during multiple runs in a single day.

Sample folder name: `20-Feb-2019_14:29:36`